### PR TITLE
Open main CTA links in new tab

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -71,8 +71,8 @@
                     Come join developers, designers, data geeks, leaders, and idea-makers who volunteer to help local government and civic orgs adopt open web technologies.
                   </p>
                   </div>
-                  <a class="btn btn-success btn-lg" href="http://www.github.com/opencleveland/">Check out our Projects</a>
-                  <a class="btn btn-danger btn-lg" href="http://www.meetup.com/open-cleveland/">Come to our Meetups</a>
+                  <a class="btn btn-success btn-lg" href="http://www.github.com/opencleveland/" target="_blank">Check out our Projects</a>
+                  <a class="btn btn-danger btn-lg" href="http://www.meetup.com/open-cleveland/" target="_blank">Come to our Meetups</a>
                   <!-- <a class="btn btn-primary btn-lg" href="#">Join the discussion</a> PTK: we don't have a public discussion forum so commenting this out. Can update the link or permanently delete later. -->
                 </div>
               </div>


### PR DESCRIPTION
Small fix to open the two CTA links (the red and green buttons) in new tabs.

Just need something to test out git commits