### PR TITLE
Add/Update Data Sources in A guide for local Cleveland open data

### DIFF
--- a/_posts/blog/2017-09-22-guide-to-cleveland-data.md
+++ b/_posts/blog/2017-09-22-guide-to-cleveland-data.md
@@ -10,7 +10,9 @@ author: Will Skora
 
 What is open civic data? Open Civic Data (generally just referred as Open Data) is quantative data about a municipality's functions, qualities, services, its people, and physical infrastructure. The [Sunlight Foundation](<https://sunlightfoundation.com/2013/09/16/your-guidelines-to-open-data-guidelines-pt-2-stages-of-development/) and [Open Knowledge International's Open Data Handbook](<http://opendatahandbook.org/guide/en/what-is-open-data/) are two sources that explain more. 
 
+
 If you want to do anything useful with the data, the data has to be "open": able to be obtained freely and in bulk (no saving a file six hundred times) , "machine-readable" - in a file format that is friendly to work with and whose content can be deciphered by computer programs easily and to be legally able to use and share with minimal or no restrictions. 
+
 
 When we want data about our city, where do we start? First, ASK the agency that you think would have the data (Advice on that in a later post). 
 
@@ -20,8 +22,8 @@ When we want data about our city, where do we start? First, ASK the agency that 
 
 Cities across the USA have dedicated websites (data portals). Unfortunately, Cleveland doesn't have one. In this absence, different entities have aggregated or collected this data or perhaps the govt agency that produces or acts as a steward for this data may publish it themselves. 
 
-<h3>geospatial/geographic:</h3>
 
+<h3>geospatial/geographic:</h3>
 
 [https://github.com/skorasaurus/cleboundaries](https://github.com/skorasaurus/cleboundaries) 
 *  collection of spatial boundaries that Will Skora from Open Cleveland manually georeferenced or individually obtained; 
@@ -43,21 +45,40 @@ NeoCando:
 
 RTA
 <http://www.riderta.com/developers>
-..* Bus and subway routes and locations of stops; in GTFS format; 
+* Bus and subway routes and locations of stops; in GTFS format;
+
+Northeast Ohio Areawide Coordinating Agency (NOACA)
+<http://gis.noaca.org/Portal/>
+* Transportation and environmental planning agency serving Cuyahoga, Geauga, Lake, Lorain and Medina counties public data
+
 
 <h3>Elections:</h3>
 
 <http://boe.cuyahogacounty.us>
-:   campaign finance reports are available in PDF
+* campaign finance reports are available in PDF
+
 
 <h3>Health:</h3>
 
 <http://www.healthdatamatters.org>
 
+
+<h3>Weather:</h3>
+
+National Oceanic and Atmospheric Administration (NOAA)
+<https://data.noaa.gov/onestop/#/>
+* NOAA data search platform
+
+Former National Climatic Data Center (NCDC)
+<https://www.ncdc.noaa.gov/>
+* Climate and historical weather data and information
+* Now affiliated with NOAA
+
+
 <h3>Other:</h3> 
 
 Cleveland's Open Data Census
-<http://us-city.census.okfn.org/place/cleveland>
+<http://us-cities.survey.okfn.org/place/cleveland>
 
 
 <h3>For all of Ohio:</h3>
@@ -65,6 +86,7 @@ Cleveland's Open Data Census
 <http://ogrip.oit.ohio.go>
 * state-wide geographic data (roads, railroads, addresses, parcels)
 * may not be the most up to date, search the particular county's GIS website for an updated data set. 
+
 
 <h3>Tips:</h3>
 

--- a/_posts/blog/2017-09-22-guide-to-cleveland-data.md
+++ b/_posts/blog/2017-09-22-guide-to-cleveland-data.md
@@ -66,10 +66,12 @@ Northeast Ohio Areawide Coordinating Agency (NOACA)
 <h3>Weather:</h3>
 
 National Oceanic and Atmospheric Administration (NOAA)
+
 <https://data.noaa.gov/onestop/#/>
 * NOAA data search platform
 
 Former National Climatic Data Center (NCDC)
+
 <https://www.ncdc.noaa.gov/>
 * Climate and historical weather data and information
 * Now affiliated with NOAA
@@ -78,6 +80,7 @@ Former National Climatic Data Center (NCDC)
 <h3>Other:</h3> 
 
 Cleveland's Open Data Census
+
 <http://us-cities.survey.okfn.org/place/cleveland>
 
 

--- a/_posts/blog/2017-09-22-guide-to-cleveland-data.md
+++ b/_posts/blog/2017-09-22-guide-to-cleveland-data.md
@@ -8,40 +8,41 @@ author: Will Skora
 
 # A guide for local Cleveland open data
 
-What is open civic data? Open Civic Data (generally just referred as Open Data) is quantative data about a municipality's functions, qualities, services, its people, and physical infrastructure. The [Sunlight Foundation](<https://sunlightfoundation.com/2013/09/16/your-guidelines-to-open-data-guidelines-pt-2-stages-of-development/) and [Open Knowledge International's Open Data Handbook](<http://opendatahandbook.org/guide/en/what-is-open-data/) are two sources that explain more. 
+What is open civic data? Open Civic Data (generally just referred as Open Data) is quantative data about a municipality's functions, qualities, services, its people, and physical infrastructure. The [Sunlight Foundation](<https://sunlightfoundation.com/2013/09/16/your-guidelines-to-open-data-guidelines-pt-2-stages-of-development/) and [Open Knowledge International's Open Data Handbook](<http://opendatahandbook.org/guide/en/what-is-open-data/) are two sources that explain more.
 
 
-If you want to do anything useful with the data, the data has to be "open": able to be obtained freely and in bulk (no saving a file six hundred times) , "machine-readable" - in a file format that is friendly to work with and whose content can be deciphered by computer programs easily and to be legally able to use and share with minimal or no restrictions. 
+If you want to do anything useful with the data, the data has to be "open": able to be obtained freely and in bulk (no saving a file six hundred times) , "machine-readable" - in a file format that is friendly to work with and whose content can be deciphered by computer programs easily and to be legally able to use and share with minimal or no restrictions.
 
 
-When we want data about our city, where do we start? First, ASK the agency that you think would have the data (Advice on that in a later post). 
+When we want data about our city, where do we start? First, ASK the agency that you think would have the data (Advice on that in a later post).
 
 
-[The US Census](https://www.census.gov/data.html) is a comprehensive source of data about our city specifically on our population and demographics. 
+[The US Census](https://www.census.gov/data.html) is a comprehensive source of data about our city specifically on our population and demographics.
 
 
-Cities across the USA have dedicated websites (data portals). Unfortunately, Cleveland doesn't have one. In this absence, different entities have aggregated or collected this data or perhaps the govt agency that produces or acts as a steward for this data may publish it themselves. 
+Cities across the USA have dedicated websites (data portals). Unfortunately, Cleveland doesn't have one. In this absence, different entities have aggregated or collected this data or perhaps the govt agency that produces or acts as a steward for this data may publish it themselves.
 
 
 <h3>geospatial/geographic:</h3>
 
-[https://github.com/skorasaurus/cleboundaries](https://github.com/skorasaurus/cleboundaries) 
-*  collection of spatial boundaries that Will Skora from Open Cleveland manually georeferenced or individually obtained; 
-City of Cleveland's police districts, wards, landmark districts, neighborhood boundaries. 
+[https://github.com/skorasaurus/cleboundaries](https://github.com/skorasaurus/cleboundaries)
+*  collection of spatial boundaries that Will Skora from Open Cleveland manually georeferenced or individually obtained;
+City of Cleveland's police districts, wards, landmark districts, neighborhood boundaries.
 
 [https://github.com/skorasaurus/dtparking](https://github.com/skorasaurus/dtparking)
-* downtown Cleveland car parking available to the public; Will Skora from Open Cleveland manually surveyed this and keeps it relatively updated. Does not include parking meters. 
+* downtown Cleveland car parking available to the public; Will Skora from Open Cleveland manually surveyed this and keeps it relatively updated. Does not include parking meters.
 
 <http://data-cuyahoga.opendata.arcgis.com/>
 * Cuyahoga County geospatial data (roads, railroads, addresses, parcels; natural resources)
 
-NeoCando:
+**NeoCando**
+
 <http://neocando.case.edu/>
-* demographics, crime, property data, census for cuyahoga county; also property transactions; the most comprehensive source of civic data in Cleveland/Cuyahoga County
-* requires registration
+* Demographics, crime, property data, census for cuyahoga county; also property transactions; the most comprehensive source of civic data in Cleveland/Cuyahoga County
+* Requires registration
 
 
-<h3>Public Transportation:</h3>
+<h3>Transportation:</h3>
 
 **RTA**
 
@@ -51,58 +52,65 @@ NeoCando:
 **Northeast Ohio Areawide Coordinating Agency (NOACA)**
 
 <http://gis.noaca.org/Portal/>
-* Transportation and environmental planning agency serving Cuyahoga, Geauga, Lake, Lorain and Medina counties public data
+* Data on Transportation, Freight on highways, Bicycle Infrastructure, and Urban Planning
+* Data Accessible by clicking on pie-chart icon on right side of screen
 
 
 <h3>Elections:</h3>
 
+**Cuyahoga County Board of Elections**
+
 <http://boe.cuyahogacounty.us>
-* campaign finance reports are available in PDF
+* Campaign finance reports available in PDF format
 
 
 <h3>Health:</h3>
 
+**Health Data Matters**
+
 <http://www.healthdatamatters.org>
+* Health data for Cleveland and Cuyahoga county
 
 
-<h3>Weather:</h3>
-
-**National Oceanic and Atmospheric Administration (NOAA)**
-
-<https://data.noaa.gov/onestop/#/>
-* NOAA data search platform
-
-**Former National Climatic Data Center (NCDC)**
-
-<https://www.ncdc.noaa.gov/>
-* Climate and historical weather data and information
-* Now affiliated with NOAA
-
-
-<h3>Other:</h3> 
+<h3>Other:</h3>
 
 **Cleveland's Open Data Census**
 
 <http://us-cities.survey.okfn.org/place/cleveland>
+* A census describing the status of assorted public datasets in municipalities across the United States and where Cleveland ranks
 
 
 <h3>For all of Ohio:</h3>
 
 <http://ogrip.oit.ohio.go>
-* state-wide geographic data (roads, railroads, addresses, parcels)
-* may not be the most up to date, search the particular county's GIS website for an updated data set. 
+* State-wide geographic data (roads, railroads, addresses, parcels)
+* May not be the most up to date, search the particular county's GIS website for an updated data set.
+
+
+<h3>National:</h3>
+
+**National Oceanic and Atmospheric Administration (NOAA)**
+
+ <https://data.noaa.gov/onestop/#/>
+* Weather, climate, satellites, fisheries, coasts, and oceans
+
+ **Former National Climatic Data Center (NCDC)**
+
+ <https://www.ncdc.noaa.gov/>
+* Climate and historical weather data and information
+* Now affiliated with NOAA
 
 
 <h3>Tips:</h3>
 
-Still unsure where it is or can't find it? 
+Still unsure where it is or can't find it?
 <ul>
 <li>Ask us by opencleveland@gmail.com or on twitter @opencleveland and we'll try put you in touch with who has it.</li>
 <li> ask your local librarian at your local public library. :)  </li>
 
 </ul>
 
-We'll try to keep this up to date and encourage you to share by email (opencleveland@gmail.com) 
+We'll try to keep this up to date and encourage you to share by email (opencleveland@gmail.com)
 
 
 Next step: How to ask for the data if it's not publicly available.

--- a/_posts/blog/2017-09-22-guide-to-cleveland-data.md
+++ b/_posts/blog/2017-09-22-guide-to-cleveland-data.md
@@ -32,6 +32,7 @@ City of Cleveland's police districts, wards, landmark districts, neighborhood bo
 [https://github.com/skorasaurus/dtparking](https://github.com/skorasaurus/dtparking)
 * downtown Cleveland car parking available to the public; Will Skora from Open Cleveland manually surveyed this and keeps it relatively updated. Does not include parking meters.
 
+**Cuyahoga County Open Data**
 <http://data-cuyahoga.opendata.arcgis.com/>
 * Cuyahoga County geospatial data (roads, railroads, addresses, parcels; natural resources)
 
@@ -82,7 +83,9 @@ City of Cleveland's police districts, wards, landmark districts, neighborhood bo
 
 <h3>For all of Ohio:</h3>
 
-<http://ogrip.oit.ohio.go>
+**Ohio Geographically Referenced Information Program (OGRIP)**
+
+<http://ogrip.oit.ohio.gov>
 * State-wide geographic data (roads, railroads, addresses, parcels)
 * May not be the most up to date, search the particular county's GIS website for an updated data set.
 

--- a/_posts/blog/2017-09-22-guide-to-cleveland-data.md
+++ b/_posts/blog/2017-09-22-guide-to-cleveland-data.md
@@ -43,11 +43,13 @@ NeoCando:
 
 <h3>Public Transportation:</h3>
 
-RTA
+**RTA**
+
 <http://www.riderta.com/developers>
 * Bus and subway routes and locations of stops; in GTFS format;
 
-Northeast Ohio Areawide Coordinating Agency (NOACA)
+**Northeast Ohio Areawide Coordinating Agency (NOACA)**
+
 <http://gis.noaca.org/Portal/>
 * Transportation and environmental planning agency serving Cuyahoga, Geauga, Lake, Lorain and Medina counties public data
 
@@ -65,12 +67,12 @@ Northeast Ohio Areawide Coordinating Agency (NOACA)
 
 <h3>Weather:</h3>
 
-National Oceanic and Atmospheric Administration (NOAA)
+**National Oceanic and Atmospheric Administration (NOAA)**
 
 <https://data.noaa.gov/onestop/#/>
 * NOAA data search platform
 
-Former National Climatic Data Center (NCDC)
+**Former National Climatic Data Center (NCDC)**
 
 <https://www.ncdc.noaa.gov/>
 * Climate and historical weather data and information
@@ -79,7 +81,7 @@ Former National Climatic Data Center (NCDC)
 
 <h3>Other:</h3> 
 
-Cleveland's Open Data Census
+**Cleveland's Open Data Census**
 
 <http://us-cities.survey.okfn.org/place/cleveland>
 

--- a/_posts/blog/2017-09-22-guide-to-cleveland-data.md
+++ b/_posts/blog/2017-09-22-guide-to-cleveland-data.md
@@ -33,6 +33,7 @@ City of Cleveland's police districts, wards, landmark districts, neighborhood bo
 * downtown Cleveland car parking available to the public; Will Skora from Open Cleveland manually surveyed this and keeps it relatively updated. Does not include parking meters.
 
 **Cuyahoga County Open Data**
+
 <http://data-cuyahoga.opendata.arcgis.com/>
 * Cuyahoga County geospatial data (roads, railroads, addresses, parcels; natural resources)
 


### PR DESCRIPTION
Closes #47 
Closes #45 

This pull requests adds the following to the [A guide for local Cleveland open data](http://www.opencleveland.org/blog/guide-to-cleveland-data/) blog:
* [National Oceanic and Atmospheric Administration (NOAA)](https://data.noaa.gov/onestop/#)
* [Former National Climatic Data Center (NCDC)](https://www.ncdc.noaa.gov/)
* [Northeast Ohio Areawide Coordinating Agency (NOACA)](http://gis.noaca.org/Portal/)
* Updated Cleveland census data link that was used in #46 
* Slight style/formatting changes

Considerations:
* Should all data sources have a bold title before the data link, such as what I included with RTA, etc.
* Are the descriptions I have included for the data links acceptable
* Placement of data links in certain categories