### PR TITLE
remove broken button of how to help

### DIFF
--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -19,12 +19,6 @@
   		{% endfor %}
 	</div>
 	<div class="col-md-4">
-		<div class="list-group">
-			<h2 class="first needs">Needs</h2>
-			<button type="button" class="btn btn-success btn-block">I want to Help!</button>
-		</div>
-
-		<h2 class="code">Code</h2>
 
 	</div>
 </div>


### PR DESCRIPTION

This commit removes the how to help button. 
![Selection_002](https://user-images.githubusercontent.com/955351/89739875-39cb0000-da52-11ea-85ae-c8f8bf2e9d19.jpg)

[The how to help button was never properly implemented in the first place](https://github.com/opencleveland/opencleveland.github.io/blob/0a425a64746aaf692a215022c9fd67494a02b300/_layouts/projects.html). When doing an action on the button (clicking or pressing enter when focus was on the element); nothing happened. 

I think the originally intention was that below the how to help button in that right hand side of the page, was a section immediately below that used the CFApi which was load in open github issues associated with that particular project.; 

the [CFA api](https://github.com/codeforamerica/cfapi), is no longer maintained although its goal - providing an automated way of viewing activity in brigades' github repositories was good.  

Right now, the how to help section that is in each project works better where we can list specific issues. 

closes #59 

Instead, for the immediate future, if we want to , we should just list the issues needed and/or provide a link to the project's github repository. 